### PR TITLE
Configure ENV variables using .env file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+ADMIN_NAME=admin
+ADMIN_PASSWORD=admin

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-debug.log*
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,8 @@ group :development, :test do
 
   # Use Factory Bot for testing factories.
   gem "factory_bot_rails"
+
+  gem "dotenv-rails", "~> 2.1"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     docile (1.3.2)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     early (0.3.1)
     erubi (1.12.0)
     factory_bot (5.1.1)
@@ -323,6 +327,7 @@ DEPENDENCIES
   capybara (>= 2.15.0)
   clockwork
   debug
+  dotenv-rails (~> 2.1)
   early
   factory_bot_rails
   icalendar

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,6 @@
 # frozen_string_literal: true
 
 require "fileutils"
-include FileUtils
 
 # path to your application root.
 APP_ROOT = File.expand_path("..", __dir__)
@@ -11,7 +10,7 @@ def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
 end
 
-chdir APP_ROOT do
+FileUtils.chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
@@ -19,13 +18,10 @@ chdir APP_ROOT do
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
 
-  # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
-
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  puts "\n== Copying ENV file =="
+  unless File.exist?(".env")
+    FileUtils.cp(".env.template", ".env")
+  end
 
   puts "\n== Preparing database =="
   system! "bin/rails db:setup"


### PR DESCRIPTION
- Ignore `.env` file.
- Install `dotenv-rails` gem to load ENV variables from `.env`.
- Update the setup script to copy `.env.template` to `.env`.