### PR TITLE
Add NOT NULL constraint to events.venue_id

### DIFF
--- a/db/migrate/20230630143115_add_not_null_constraint_to_venue_id_on_events.rb
+++ b/db/migrate/20230630143115_add_not_null_constraint_to_venue_id_on_events.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToVenueIdOnEvents < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :events, :venue_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_30_124814) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_30_143115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -67,7 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_124814) do
     t.datetime "meetup_published_at", precision: nil
     t.string "online_url", default: ""
     t.string "name"
-    t.bigint "venue_id"
+    t.bigint "venue_id", null: false
     t.index ["venue_id"], name: "index_events_on_venue_id"
   end
 


### PR DESCRIPTION
Once we ensure all events in the databaase are associated with venues, we can improve the data integrity by making the `events.venue_id` column not nullable.

The migration is done in a naive way since we have around 50 events at the moment and blocking the table shouldn't be a problem.